### PR TITLE
Add key constraints

### DIFF
--- a/rules/constraint.go
+++ b/rules/constraint.go
@@ -1,0 +1,6 @@
+package rules
+
+type constraint struct {
+	prefix string
+	chars  [][]rune
+}

--- a/rules/engine.go
+++ b/rules/engine.go
@@ -73,7 +73,7 @@ func NewV3Engine(configV3 clientv3.Config, logger zap.Logger, options ...EngineO
 
 func newEngine(config client.Config, configV3 clientv3.Config, useV3 bool, logger zap.Logger, options ...EngineOption) engine {
 	opts := makeEngineOptions(options...)
-	ruleMgr := newRuleManager()
+	ruleMgr := newRuleManager(map[string]constraint{})
 	channel := make(chan ruleWork)
 	keyProc := newKeyProcessor(channel, config, &ruleMgr)
 	eng := engine{
@@ -94,7 +94,7 @@ func newEngine(config client.Config, configV3 clientv3.Config, useV3 bool, logge
 
 func newV3Engine(config client.Config, configV3 clientv3.Config, useV3 bool, logger zap.Logger, options ...EngineOption) v3Engine {
 	opts := makeEngineOptions(options...)
-	ruleMgr := newRuleManager()
+	ruleMgr := newRuleManager(opts.constraints)
 	channel := make(chan v3RuleWork)
 	keyProc := newV3KeyProcessor(channel, &configV3, &ruleMgr)
 	eng := v3Engine{

--- a/rules/key_processor_test.go
+++ b/rules/key_processor_test.go
@@ -13,7 +13,7 @@ func TestKeyProcessor(t *testing.T) {
 	value := "value"
 	rule, err := NewEqualsLiteralRule("/test/:key", &value)
 	assert.NoError(t, err)
-	rm := newRuleManager()
+	rm := newRuleManager(map[string]constraint{})
 	rm.addRule(rule)
 	api := newMapReadAPI()
 	api.put("/test/key", value)
@@ -60,7 +60,7 @@ func TestV3KeyProcessor(t *testing.T) {
 	value := "value"
 	rule, err := NewEqualsLiteralRule("/test/:key", &value)
 	assert.NoError(t, err)
-	rm := newRuleManager()
+	rm := newRuleManager(map[string]constraint{})
 	rm.addRule(rule)
 	api := newMapReadAPI()
 	api.put("/test/key", value)

--- a/rules/matcher_test.go
+++ b/rules/matcher_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func TestBasic(t *testing.T) {
-	test := "/user/:name"
+	test := "/user/:name/state"
 
 	km, _ := newRegexKeyMatcher(test)
-	match, ok := km.match("/user/john")
+	match, ok := km.match("/user/john/state")
 	assert.True(t, ok)
 	value := *match.GetAttribute("name")
 	if value != "john" {
@@ -31,6 +31,17 @@ func TestBasic(t *testing.T) {
 		t.Logf("Incorrect prefix: %s", prefix)
 		t.Fail()
 	}
+	prefixes := km.getPrefixesWithConstraints(map[string]constraint{
+		"name": constraint{
+			prefix: "xy",
+			chars:  [][]rune{{'a', 'b'}, {'a', 'b'}},
+		},
+	})
+	assert.Equal(t, 4, len(prefixes))
+	assert.Equal(t, "/user/xyaa", prefixes[0])
+	assert.Equal(t, "/user/xyab", prefixes[1])
+	assert.Equal(t, "/user/xyba", prefixes[2])
+	assert.Equal(t, "/user/xybb", prefixes[3])
 	format = match.Format("/test/:asdf")
 	assert.Equal(t, "/test/:asdf", format)
 }

--- a/rules/options.go
+++ b/rules/options.go
@@ -4,6 +4,7 @@ import ()
 
 type engineOptions struct {
 	concurrency, syncGetTimeout, syncInterval, watchTimeout int
+	constraints                                             map[string]constraint
 	lockTimeout                                             int
 	keyExpansion                                            map[string][]string
 }
@@ -11,6 +12,7 @@ type engineOptions struct {
 func makeEngineOptions(options ...EngineOption) engineOptions {
 	opts := engineOptions{
 		concurrency:    5,
+		constraints:    map[string]constraint{},
 		lockTimeout:    30,
 		syncInterval:   300,
 		syncGetTimeout: 0,
@@ -62,6 +64,17 @@ func EngineWatchTimeout(watchTimeout int) EngineOption {
 func KeyExpansion(keyExpansion map[string][]string) EngineOption {
 	return engineOptionFunction(func(o *engineOptions) {
 		o.keyExpansion = keyExpansion
+	})
+}
+
+// KeyConstraint enables multiple query prefixes to be generated for a specific
+// attribute as a way to limit the scope of a query for a prefix query.
+func KeyConstraint(attribute string, prefix string, chars [][]rune) EngineOption {
+	return engineOptionFunction(func(o *engineOptions) {
+		o.constraints[attribute] = constraint{
+			chars:  chars,
+			prefix: prefix,
+		}
 	})
 }
 

--- a/rules/rule_manager.go
+++ b/rules/rule_manager.go
@@ -5,15 +5,17 @@ import (
 )
 
 type ruleManager struct {
+	constraints       map[string]constraint
+	currentIndex      int
 	rulesBySlashCount map[int]map[DynamicRule]int
 	prefixes          map[string]string
-	currentIndex      int
 }
 
-func newRuleManager() ruleManager {
+func newRuleManager(constraints map[string]constraint) ruleManager {
 	rm := ruleManager{
 		rulesBySlashCount: map[int]map[DynamicRule]int{},
 		prefixes:          map[string]string{},
+		constraints:       constraints,
 		currentIndex:      0,
 	}
 	return rm
@@ -44,7 +46,7 @@ func (rm *ruleManager) addRule(rule DynamicRule) int {
 		}
 		rules[rule] = rm.currentIndex
 	}
-	for _, prefix := range rule.getPrefixes() {
+	for _, prefix := range rule.getPrefixesWithConstraints(rm.constraints) {
 		rm.prefixes[prefix] = ""
 	}
 	rm.prefixes = reducePrefixes(rm.prefixes)

--- a/rules/rule_manager_test.go
+++ b/rules/rule_manager_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRuleManager(t *testing.T) {
-	rm := newRuleManager()
+	rm := newRuleManager(map[string]constraint{})
 	rule1, err1 := NewEqualsLiteralRule("/this/is/:a/rule", nil)
 	assert.NoError(t, err1)
 	rm.addRule(rule1)


### PR DESCRIPTION
This enables the v3 crawler to perform prefix queries using partial
identifiers.