### PR TITLE
Change background contexts to timeout contexts for v3

### DIFF
--- a/rules/crawler.go
+++ b/rules/crawler.go
@@ -128,8 +128,9 @@ func (v3ec *v3EtcdCrawler) run() {
 }
 
 func (v3ec *v3EtcdCrawler) singleRun() {
-	// This won't scale
-	resp, err := v3ec.kv.Get(context.Background(), v3ec.prefix, clientv3.WithPrefix())
+	ctx, cancelFunc := context.WithTimeout(context.Background(), time.Duration(1)*time.Minute)
+	defer cancelFunc()
+	resp, err := v3ec.kv.Get(ctx, v3ec.prefix, clientv3.WithPrefix())
 	if err != nil {
 		return
 	}

--- a/rules/engine.go
+++ b/rules/engine.go
@@ -313,14 +313,16 @@ func (cbw *v3CallbackWrapper) doRule(task *V3RuleTask) {
 	logger.Debug("Setting polling TTL", zap.String("path", path))
 	lease := clientv3.NewLease(c)
 	ctx, cancelFunc := context.WithTimeout(context.Background(), time.Duration(5)*time.Second)
+	defer cancelFunc()
 	resp, leaseErr := lease.Grant(ctx, int64(cbw.ttl))
 	if leaseErr != nil {
 		logger.Error("Error obtaining lease", zap.Error(leaseErr), zap.String("path", path))
-		cancelFunc()
 		return
 	}
+	ctx1, cancelFunc1 := context.WithTimeout(context.Background(), time.Duration(5)*time.Second)
+	defer cancelFunc1()
 	_, setErr := kv.Put(
-		context.Background(),
+		ctx1,
 		path,
 		"",
 		clientv3.WithLease(resp.ID),

--- a/rules/lock.go
+++ b/rules/lock.go
@@ -78,6 +78,7 @@ type v3Lock struct {
 func (v3l *v3Lock) unlock() {
 	ctx, canfunc := context.WithTimeout(context.Background(), time.Duration(5)*time.Second)
 	err := v3l.mutex.Unlock(ctx)
-	if err != nil {}
+	if err != nil {
+	}
 	canfunc()
 }

--- a/rules/lock.go
+++ b/rules/lock.go
@@ -63,9 +63,9 @@ func (v3l *v3Locker) lockWithTimeout(key string, ttl int, timeout int) (ruleLock
 	}
 	m := concurrency.NewMutex(s, key)
 	ctx, canfunc := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	defer canfunc()
 	err2 := m.Lock(ctx)
 	if err2 != nil {
-		canfunc()
 		return nil, err2
 	}
 	return &v3Lock{m}, nil
@@ -78,7 +78,6 @@ type v3Lock struct {
 func (v3l *v3Lock) unlock() {
 	ctx, canfunc := context.WithTimeout(context.Background(), time.Duration(5)*time.Second)
 	err := v3l.mutex.Unlock(ctx)
-	if err != nil {
-		canfunc()
-	}
+	if err != nil {}
+	canfunc()
 }

--- a/rules/options.go
+++ b/rules/options.go
@@ -78,6 +78,8 @@ func KeyConstraint(attribute string, prefix string, chars [][]rune) EngineOption
 	})
 }
 
+// EngineSyncInterval enables the interval between sync or crawler runs to be configured.
+// The interval is in seconds.
 func EngineSyncInterval(interval int) EngineOption {
 	return engineOptionFunction(func(o *engineOptions) {
 		o.syncInterval = interval

--- a/rules/watcher.go
+++ b/rules/watcher.go
@@ -6,7 +6,6 @@ import (
 	"github.com/coreos/etcd/client"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/uber-go/zap"
-	"golang.org/x/net/context"
 )
 
 func newWatcher(config client.Config, prefix string, logger zap.Logger, proc keyProc, watchTimeout int) (watcher, error) {
@@ -66,8 +65,4 @@ func (w *watcher) singleRun() {
 		return
 	}
 	w.kp.processKey(key, value, w.api, w.logger)
-}
-
-func (w *watcher) getContext() context.Context {
-	return context.Background()
 }

--- a/rules/watcher_test.go
+++ b/rules/watcher_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
+	//	"golang.org/x/net/context"
 )
 
 func TestWatcher(t *testing.T) {
@@ -26,7 +26,7 @@ func TestWatcher(t *testing.T) {
 	w.singleRun()
 	assert.Equal(t, "key1", kp.keys[0])
 	assert.Equal(t, &value1, kp.values[0])
-	assert.Equal(t, context.Background(), w.getContext())
+	//	assert.Equal(t, context.Background(), w.getContext())
 	w.singleRun()
 }
 


### PR DESCRIPTION
V3 will hang on operations that would normally error out on v2, so
every operation needs a timeout context so the overall application
does not hang.