### PR TITLE
Fix Not rule satisfiability and Equals rule

### DIFF
--- a/rules/dynamic_rule_test.go
+++ b/rules/dynamic_rule_test.go
@@ -171,7 +171,6 @@ func TestNotRule(t *testing.T) {
 	notRule, attr, ok := test.makeStaticRule("/us-south/actual/clusters/armada-9b93c18d/workers/worker3", &value)
 	assert.True(t, ok)
 	assert.True(t, notRule.satisfiable("/us-south/actual/clusters/armada-9b93c18d/workers/worker3", &value))
-	assert.False(t, notRule.satisfiable("/us-south/actual/clusters/armada-9b93c18d/workers/worker3", nil))
 	api := newMapReadAPI()
 	var sat bool
 	sat, _ = notRule.satisfied(api)

--- a/rules/static_rule.go
+++ b/rules/static_rule.go
@@ -153,7 +153,7 @@ func (nsr *notStaticRule) keyMatch(key string) bool {
 }
 
 func (nsr *notStaticRule) satisfiable(key string, value *string) bool {
-	return nsr.nested.keyMatch(key) && !nsr.nested.satisfiable(key, value)
+	return nsr.nested.keyMatch(key)
 }
 
 func (nsr *notStaticRule) satisfied(api readAPI) (bool, error) {
@@ -190,20 +190,32 @@ func (er *equalsRule) satisfied(api readAPI) (bool, error) {
 		return true, nil
 	}
 	ref, err1 := api.get(er.keys[0])
+	// Failed to get reference value?
 	if err1 != nil {
 		return false, err1
 	}
-	for _, key := range er.keys {
+	for index, key := range er.keys {
+		if index == 0 {
+			continue
+		}
+		// Failed to get next value?
 		value, err2 := api.get(key)
 		if err2 != nil {
 			return false, err2
 		}
+		// Value is nil
 		if value == nil {
+			// Reference value isn't
 			if ref != nil {
 				return false, nil
 			}
 		} else {
+			// Value is not nil but reference is
 			if ref == nil {
+				return false, nil
+			}
+			// Neither is nil
+			if *ref != *value {
 				return false, nil
 			}
 		}


### PR DESCRIPTION
The Not rule was only satisfiable if its nested rule was not
satisfiable, which did not work with the equals rule. The
equals rule had a bug where two values were not compared if
neither of them was nil.