### PR TITLE
Fixing compound rule logic

### DIFF
--- a/rules/static_rule.go
+++ b/rules/static_rule.go
@@ -54,16 +54,7 @@ func (elrf *equalsLiteralRuleFactory) newRule(keys []string, attr Attributes) st
 }
 
 func (elr *equalsLiteralRule) satisfiable(key string, value *string) bool {
-	if key != elr.key {
-		return false
-	}
-	if value == nil {
-		return elr.value == nil
-	}
-	if elr.value == nil {
-		return false
-	}
-	return *value == *elr.value
+	return key == elr.key
 }
 
 func (elr *equalsLiteralRule) satisfied(api readAPI) (bool, error) {
@@ -71,7 +62,13 @@ func (elr *equalsLiteralRule) satisfied(api readAPI) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return elr.satisfiable(elr.key, value), nil
+	if value == nil {
+		return elr.value == nil, nil
+	}
+	if elr.value == nil {
+		return false, nil
+	}
+	return *value == *elr.value, nil
 }
 
 func (elr *equalsLiteralRule) keyMatch(key string) bool {

--- a/rules/static_rule_test.go
+++ b/rules/static_rule_test.go
@@ -130,7 +130,7 @@ func TestEqualsLiteralOnlyRuleNil(t *testing.T) {
 		value: nil,
 	}
 	result := rule.satisfiable("/prefix/mykey", &queryValue)
-	assert.False(t, result)
+	assert.True(t, result)
 }
 
 func TestEqualsLiteralOnlyQueryNil(t *testing.T) {
@@ -140,21 +140,8 @@ func TestEqualsLiteralOnlyQueryNil(t *testing.T) {
 		value: &ruleValue,
 	}
 	result := rule.satisfiable("/prefix/mykey", nil)
-	assert.False(t, result)
+	assert.True(t, result)
 }
-
-//type mapAttributes struct {
-//	attr map[string]string
-//}
-//
-//func (ma *mapAttributes) GetAttribute(key string) *string {
-//	value, _ := ma.attr[key]
-//	return &value
-//}
-//
-//func (ma *mapAttributes) Format(s string) string {
-//	return formatWithAttributes(s, ma)
-//}
 
 func TestEqualsLiteralFactory(t *testing.T) {
 	value := "val1"


### PR DESCRIPTION
The case of a literal Nil rule as the only member inside an AND rule
inside a NOT rule was not working.  An equals literal must be
satisfiable when the triggering key equals the rule's key and no
other restrictions, because the rule may be inside a compound rule
inside a NOT rule.