### PR TITLE
Change crawler start/stop msgs to Info

### DIFF
--- a/rules/crawler.go
+++ b/rules/crawler.go
@@ -123,9 +123,9 @@ type etcdCrawler struct {
 func (ec *etcdCrawler) run() {
 	atomicSet(&ec.stopped, false)
 	for !ec.isStopping() {
-		ec.logger.Debug("Starting crawler run")
+		ec.logger.Info("Starting crawler run")
 		ec.singleRun()
-		ec.logger.Debug("Crawler run complete")
+		ec.logger.Info("Crawler run complete")
 		for i := 0; i < ec.interval; i++ {
 			time.Sleep(time.Second)
 			if ec.isStopping() {


### PR DESCRIPTION
It is quite useful to see when a crawler run begins and ends - but if I enable debug I get swamped with log messages. I don't think there should be too many crawler stop/starts so should be OK to make these log messages Info?